### PR TITLE
Integer division issue resolved

### DIFF
--- a/Word2Vec.Net/Word2Vec.cs
+++ b/Word2Vec.Net/Word2Vec.cs
@@ -85,7 +85,7 @@ namespace Word2Vec.Net
             _expTable = new float[ExpTableSize + 1];
             for (var i = 0; i < ExpTableSize; i++)
             {
-                _expTable[i] = (float) Math.Exp((i/ExpTableSize*2 - 1)*MaxExp); // Precompute the exp() table
+                _expTable[i] = (float) Math.Exp((i/(float)ExpTableSize*2 - 1)*MaxExp); // Precompute the exp() table
                 _expTable[i] = _expTable[i]/(_expTable[i] + 1); // Precompute f(x) = x / (x + 1)
             }
             _readVocabFile = readVocubFileName;


### PR DESCRIPTION
The previously missing float cast in the initialization of the _expTable
leads to a different effective activation function, ie., one with 2
steps:
- the first step at x=(-MaxExp) to 1.0/(1.0+exp(MaxExp)) \approx 0.0025
  for MaxExp=6
- the second at x=MaxExp from 1.0/(1.0+exp(MaxExp)) to 1.0
  This is essentially a step function with an effective bias.
